### PR TITLE
Minor bugfix for type A shortcut

### DIFF
--- a/models/resnet.lua
+++ b/models/resnet.lua
@@ -38,7 +38,7 @@ local function createModel(opt)
             :add(nn.SpatialAveragePooling(1, 1, stride, stride))
             :add(nn.Concat(2)
                :add(nn.Identity())
-               :add(nn.MulConstant(0)))
+               :add(nn.Sequential():add(Convolution(nInputPlane, nOutputPlane-nInputPlane, 1, 1, 1, 1)):add(nn.MulConstant(0))))
       else
          return nn.Identity()
       end


### PR DESCRIPTION
The original one gave me an error when shorcut = type A and nOutputPlane ~= nInpuPlane x 2 (when opt.dataset = imagenet). 

This might not be the optimal solution, but I think it could be a palliative for now. 

Best regards, 

Jaehyun