### PR TITLE
Fix typos and pre-activation types in preresnet

### DIFF
--- a/models/preresnet.lua
+++ b/models/preresnet.lua
@@ -82,7 +82,7 @@ local function createModel(opt)
       s:add(SBatchNorm(n))
       s:add(ReLU(true))
       s:add(Convolution(n,n,3,3,stride,stride,1,1))
-      s:add(SBatchNorm(n * 4))
+      s:add(SBatchNorm(n))
       s:add(ReLU(true))
       s:add(Convolution(n,n*4,1,1,1,1,0,0))
 
@@ -94,10 +94,10 @@ local function createModel(opt)
    end
 
    -- Creates count residual blocks with specified number of features
-   local function layer(block, features, count, stride)
+   local function layer(block, features, count, stride, type)
       local s = nn.Sequential()
       for i=1,count do
-         s:add(block(features, i == 1 and stride or 1))
+         s:add(block(features, i == 1 and stride or 1, type))
       end
       return s
    end


### PR DESCRIPTION
Quick fix for the typos raised in #41 and #36 (the second bullet).

According to the paper and the [code here](https://github.com/KaimingHe/resnet-1k-layers/blob/master/resnet-pre-act.lua), there could be three types of pre-activation residual unit.

| Type        | Main branch | Side branch                | Where                                                                |
|-------------|-------------|----------------------------|----------------------------------------------------------------------|
| no_preact   | conv        | conv→act→conv→act→conv     | the very first residual unit of ImageNet models                      |
| both_preact | act→conv    | act→conv→act→conv→act→conv | the first residual unit of each layer (except for the no_preact one) |
| normal      | identity    | act→conv→act→conv→act→conv | all other cases                                                    |

(*act* means BN + ReLU. For both_preact, we can first do the *act*, and then split into two branches.)