### PR TITLE
replace 'table.getn' with '#'

### DIFF
--- a/pretrained/extract-features.lua
+++ b/pretrained/extract-features.lua
@@ -67,7 +67,7 @@ else -- single file mode ; collect file from command line
     end
 end
 
-local number_of_files = table.getn(list_of_filenames)
+local number_of_files = #list_of_filenames
 
 if batch_size > number_of_files then batch_size = number_of_files end
 


### PR DESCRIPTION
'getn' function removed from 'table' library in lua v5.2
'extract-features.lua' will not run with 'getn' in version 5.2+