### PR TITLE
The averaged top1, top5 and loss scores are incorrectly computed by m…

### DIFF
--- a/train.lua
+++ b/train.lua
@@ -54,6 +54,7 @@ function Trainer:train(epoch, dataloader)
       self:copyInputs(sample)
 
       local output = self.model:forward(self.input):float()
+      local batchSize = output:size(1) / nCrops
       local loss = self.criterion:forward(self.model.output, self.target)
 
       self.model:zeroGradParameters()
@@ -63,10 +64,10 @@ function Trainer:train(epoch, dataloader)
       optim.sgd(feval, self.params, self.optimState)
 
       local top1, top5 = self:computeScore(output, sample.target, 1)
-      top1Sum = top1Sum + top1
-      top5Sum = top5Sum + top5
-      lossSum = lossSum + loss
-      N = N + 1
+      top1Sum = top1Sum + top1*batchSize
+      top5Sum = top5Sum + top5*batchSize
+      lossSum = lossSum + loss*batchSize
+      N = N + batchSize
 
       print((' | Epoch: [%d][%d/%d]    Time %.3f  Data %.3f  Err %1.4f  top1 %7.3f  top5 %7.3f'):format(
          epoch, n, trainSize, timer:time().real, dataTime, loss, top1, top5))
@@ -100,12 +101,13 @@ function Trainer:test(epoch, dataloader)
       self:copyInputs(sample)
 
       local output = self.model:forward(self.input):float()
+      local batchSize = output:size(1) / nCrops
       local loss = self.criterion:forward(self.model.output, self.target)
 
       local top1, top5 = self:computeScore(output, sample.target, nCrops)
-      top1Sum = top1Sum + top1
-      top5Sum = top5Sum + top5
-      N = N + 1
+      top1Sum = top1Sum + top1*batchSize
+      top5Sum = top5Sum + top5*batchSize
+      N = N + batchSize
 
       print((' | Test: [%d][%d/%d]    Time %.3f  Data %.3f  top1 %7.3f (%7.3f)  top5 %7.3f (%7.3f)'):format(
          epoch, n, size, timer:time().real, dataTime, top1, top1Sum / N, top5, top5Sum / N))

--- a/train.lua
+++ b/train.lua
@@ -54,7 +54,7 @@ function Trainer:train(epoch, dataloader)
       self:copyInputs(sample)
 
       local output = self.model:forward(self.input):float()
-      local batchSize = output:size(1) / nCrops
+      local batchSize = output:size(1)
       local loss = self.criterion:forward(self.model.output, self.target)
 
       self.model:zeroGradParameters()


### PR DESCRIPTION
…ethod train and test.

Explanations:

Assume a dataset size of N = 100, and a batch size of bs = 30.
This makes 4 batches of size 30, 30, 30, 10.
The top1Sum and top5sum are currently computed as follows:
( s1/30 + s2/30 + s3/30 + s4/10 )/4 * 100
where si are the top1 (or top5) numbers of incorrectly classified samples.

This is incorrect because the last batch has a size smaller than 30. The
correct way to compute the score is instead:
(s1 + s2 + s3 + s4)/N * 100

This error comes from assuming that M mod bs = 0, which is not always the case.