### PR TITLE
Predict probabilities for test images

### DIFF
--- a/dataloader.lua
+++ b/dataloader.lua
@@ -20,7 +20,7 @@ function DataLoader.create(opt)
    -- The train and val loader
    local loaders = {}
 
-   for i, split in ipairs{'train', 'val'} do
+   for i, split in ipairs{'train', 'val', 'test'} do
       local dataset = datasets.create(opt, split)
       loaders[i] = M.DataLoader(dataset, opt, split)
    end

--- a/dataloader.lua
+++ b/dataloader.lua
@@ -48,6 +48,7 @@ function DataLoader:__init(dataset, opt, split)
    self.threads = threads
    self.__size = sizes[1][1]
    self.batchSize = math.floor(opt.batchSize / self.nCrops)
+   self.dataset = dataset
 end
 
 function DataLoader:size()

--- a/dataloader.lua
+++ b/dataloader.lua
@@ -83,6 +83,7 @@ function DataLoader:run()
                return {
                   input = batch:view(sz * nCrops, table.unpack(imageSize)),
                   target = target,
+                  idx = indices,
                }
             end,
             function(_sample_)

--- a/dataloader.lua
+++ b/dataloader.lua
@@ -44,7 +44,7 @@ function DataLoader:__init(dataset, opt, split)
    end
 
    local threads, sizes = Threads(opt.nThreads, init, main)
-   self.nCrops = (split == 'val' and opt.tenCrop) and 10 or 1
+   self.nCrops = ((split == 'val' or split == 'test') and opt.tenCrop) and 10 or 1
    self.threads = threads
    self.__size = sizes[1][1]
    self.batchSize = math.floor(opt.batchSize / self.nCrops)

--- a/datasets/imagenet-gen.lua
+++ b/datasets/imagenet-gen.lua
@@ -108,9 +108,7 @@ local function findTestImages(dir)
       local line = f:read('*line')
       if not line then break end
 
-      local className = paths.basename(paths.dirname(line))
-      local filename = paths.basename(line)
-      local path = className .. '/' .. filename
+      local path = paths.basename(line)
 
       table.insert(imagePaths, path)
 
@@ -126,7 +124,8 @@ local function findTestImages(dir)
       ffi.copy(imagePath[i]:data(), path)
    end
 
-   return imagePath
+   local imageClass = torch.LongTensor(nImages):zero() - 1
+   return imagePath, imageClass
 end
 
 function M.exec(opt, cacheFile)
@@ -150,7 +149,7 @@ function M.exec(opt, cacheFile)
    local trainImagePath, trainImageClass = findImages(trainDir, classToIdx)
 
    print(" | finding all test images")
-   local testImagePath = findTestImages(testDir)
+   local testImagePath, testImageClass = findTestImages(testDir)
 
    local info = {
       basedir = opt.data,
@@ -165,6 +164,7 @@ function M.exec(opt, cacheFile)
       },
       test = {
          imagePath = testImagePath,
+         imageClass = testImageClass,
       },
    }
 

--- a/datasets/imagenet-gen.lua
+++ b/datasets/imagenet-gen.lua
@@ -85,6 +85,50 @@ local function findImages(dir, classToIdx)
    return imagePath, imageClass
 end
 
+
+local function findTestImages(dir)
+   local imagePath = torch.CharTensor()
+
+   ----------------------------------------------------------------------
+   -- Options for the GNU and BSD find command
+   local extensionList = {'jpg', 'png','JPG','PNG','JPEG', 'ppm', 'PPM', 'bmp', 'BMP'}
+   local findOptions = ' -iname "*.' .. extensionList[1] .. '"'
+   for i=2,#extensionList do
+      findOptions = findOptions .. ' -o -iname "*.' .. extensionList[i] .. '"'
+   end
+
+   -- Find all the images using the find command
+   local f = io.popen('find -L ' .. dir .. findOptions)
+
+   local maxLength = -1
+   local imagePaths = {}
+
+   -- Generate a list of all the images and their class
+   while true do
+      local line = f:read('*line')
+      if not line then break end
+
+      local className = paths.basename(paths.dirname(line))
+      local filename = paths.basename(line)
+      local path = className .. '/' .. filename
+
+      table.insert(imagePaths, path)
+
+      maxLength = math.max(maxLength, #path + 1)
+   end
+
+   f:close()
+
+   -- Convert the generated list to a tensor for faster loading
+   local nImages = #imagePaths
+   local imagePath = torch.CharTensor(nImages, maxLength):zero()
+   for i, path in ipairs(imagePaths) do
+      ffi.copy(imagePath[i]:data(), path)
+   end
+
+   return imagePath
+end
+
 function M.exec(opt, cacheFile)
    -- find the image path names
    local imagePath = torch.CharTensor()  -- path to each image in dataset
@@ -92,6 +136,7 @@ function M.exec(opt, cacheFile)
 
    local trainDir = paths.concat(opt.data, 'train')
    local valDir = paths.concat(opt.data, 'val')
+   local testDir = paths.concat(opt.data, 'test')
    assert(paths.dirp(trainDir), 'train directory not found: ' .. trainDir)
    assert(paths.dirp(valDir), 'val directory not found: ' .. valDir)
 
@@ -104,6 +149,9 @@ function M.exec(opt, cacheFile)
    print(" | finding all training images")
    local trainImagePath, trainImageClass = findImages(trainDir, classToIdx)
 
+   print(" | finding all test images")
+   local testImagePath = findTestImages(testDir)
+
    local info = {
       basedir = opt.data,
       classList = classList,
@@ -114,6 +162,9 @@ function M.exec(opt, cacheFile)
       val = {
          imagePath = valImagePath,
          imageClass = valImageClass,
+      },
+      test = {
+         imagePath = testImagePath,
       },
    }
 

--- a/datasets/imagenet.lua
+++ b/datasets/imagenet.lua
@@ -19,6 +19,7 @@ local ImagenetDataset = torch.class('resnet.ImagenetDataset', M)
 
 function ImagenetDataset:__init(imageInfo, opt, split)
    self.imageInfo = imageInfo[split]
+   self.classList = imageInfo['classList']
    self.opt = opt
    self.split = split
    self.dir = paths.concat(opt.data, split)

--- a/datasets/imagenet.lua
+++ b/datasets/imagenet.lua
@@ -90,7 +90,7 @@ function ImagenetDataset:preprocess()
          t.ColorNormalize(meanstd),
          t.HorizontalFlip(0.5),
       }
-   elseif self.split == 'val' then
+   elseif self.split == 'val' or self.split == 'test' then
       local Crop = self.opt.tenCrop and t.TenCrop or t.CenterCrop
       return t.Compose{
          t.Scale(256),

--- a/main.lua
+++ b/main.lua
@@ -44,7 +44,8 @@ end
 
 if opt.predictionsOnly then
    local tester = Tester(model, opt)
-   tester:test(testLoader)
+   paths, predictions = tester:test(testLoader)
+   torch.save('output.t7', {paths = paths, predictions = predictions})
    return
 end
 

--- a/main.lua
+++ b/main.lua
@@ -13,6 +13,7 @@ require 'nn'
 local DataLoader = require 'dataloader'
 local models = require 'models/init'
 local Trainer = require 'train'
+local Tester = require 'test'
 local opts = require 'opts'
 local checkpoints = require 'checkpoints'
 
@@ -30,7 +31,7 @@ local checkpoint, optimState = checkpoints.latest(opt)
 local model, criterion = models.setup(opt, checkpoint)
 
 -- Data loading
-local trainLoader, valLoader = DataLoader.create(opt)
+local trainLoader, valLoader, testLoader = DataLoader.create(opt)
 
 -- The trainer handles the training loop and evaluation on validation set
 local trainer = Trainer(model, criterion, opt, optimState)
@@ -38,6 +39,12 @@ local trainer = Trainer(model, criterion, opt, optimState)
 if opt.testOnly then
    local top1Err, top5Err = trainer:test(0, valLoader)
    print(string.format(' * Results top1: %6.3f  top5: %6.3f', top1Err, top5Err))
+   return
+end
+
+if opt.predictionsOnly then
+   local tester = Tester(model, opt)
+   tester:test(testLoader)
    return
 end
 

--- a/main.lua
+++ b/main.lua
@@ -42,7 +42,7 @@ if opt.testOnly then
    return
 end
 
-if opt.predictionsOnly then
+if opt.predict then
    local tester = Tester(model, opt)
    paths, predictions = tester:test(testLoader)
    torch.save('output.t7', {paths = paths, predictions = predictions})

--- a/opts.lua
+++ b/opts.lua
@@ -30,7 +30,7 @@ function M.parse(arg)
    cmd:option('-epochNumber',     1,       'Manual epoch number (useful on restarts)')
    cmd:option('-batchSize',       32,      'mini-batch size (1 = pure stochastic)')
    cmd:option('-testOnly',        'false', 'Run on validation set only')
-   cmd:option('-predictionsOnly', 'false', 'Run on test set only and produce file with predictions')
+   cmd:option('-predict',         'false', 'Run on test set only and produce file with predictions')
    cmd:option('-tenCrop',         'false', 'Ten-crop testing')
    cmd:option('-resume',          'none',  'Path to directory containing checkpoint')
    ---------- Optimization options ----------------------
@@ -52,7 +52,7 @@ function M.parse(arg)
    local opt = cmd:parse(arg or {})
 
    opt.testOnly = opt.testOnly ~= 'false'
-   opt.predictionsOnly = opt.predictionsOnly ~= 'false'
+   opt.predict = opt.predict ~= 'false'
    opt.tenCrop = opt.tenCrop ~= 'false'
    opt.shareGradInput = opt.shareGradInput ~= 'false'
    opt.resetClassifier = opt.resetClassifier ~= 'false'

--- a/opts.lua
+++ b/opts.lua
@@ -30,6 +30,7 @@ function M.parse(arg)
    cmd:option('-epochNumber',     1,       'Manual epoch number (useful on restarts)')
    cmd:option('-batchSize',       32,      'mini-batch size (1 = pure stochastic)')
    cmd:option('-testOnly',        'false', 'Run on validation set only')
+   cmd:option('-predictionsOnly', 'false', 'Run on test set only and produce file with predictions')
    cmd:option('-tenCrop',         'false', 'Ten-crop testing')
    cmd:option('-resume',          'none',  'Path to directory containing checkpoint')
    ---------- Optimization options ----------------------
@@ -51,6 +52,7 @@ function M.parse(arg)
    local opt = cmd:parse(arg or {})
 
    opt.testOnly = opt.testOnly ~= 'false'
+   opt.predictionsOnly = opt.predictionsOnly ~= 'false'
    opt.tenCrop = opt.tenCrop ~= 'false'
    opt.shareGradInput = opt.shareGradInput ~= 'false'
    opt.resetClassifier = opt.resetClassifier ~= 'false'

--- a/test.lua
+++ b/test.lua
@@ -34,10 +34,10 @@ function Tester:test(dataloader)
       local output = self.model:forward(sample.input:cuda():contiguous()):float()
       if self.nCrops > 1 then
         -- Sum over crops
-        output = output:view(output:size(1) / nCrops, nCrops, output:size(2))
+        output = output:view(output:size(1) / self.nCrops, self.nCrops, output:size(2))
           --:exp()
           :sum(2):squeeze(2)
-         output = output / nCrops
+         output = output / self.nCrops
       end
 
       local start = numProcessed + 1

--- a/test.lua
+++ b/test.lua
@@ -6,10 +6,8 @@
 --  LICENSE file in the root directory of this source tree. An additional grant
 --  of patent rights can be found in the PATENTS file in the same directory.
 --
--- require 'torch'
---
--- torch.setdefaulttensortype('torch.FloatTensor')
--- torch.setnumthreads(1)
+
+local ffi = require 'ffi'
 
 local M = {}
 local Tester = torch.class('resnet.Tester', M)
@@ -57,8 +55,8 @@ function Tester:test(dataloader)
     file = io.open('output.csv', 'w')
 
     for i=1,(predictions:size(1)) do
-       print(predictions[i])
-       s = indices[i]
+       local path = ffi.string(dataloader.dataset.imageInfo.imagePath[indices[i]]:data())
+       s = path
        for j=1,4 do
             s = s..','..predictions[i][j]
        end

--- a/test.lua
+++ b/test.lua
@@ -48,22 +48,11 @@ function Tester:test(dataloader)
       numProcessed = numProcessed + output:size(1)
    end
 
-
-
-
-
-    file = io.open('output.csv', 'w')
-
-    for i=1,(predictions:size(1)) do
-       local path = ffi.string(dataloader.dataset.imageInfo.imagePath[indices[i]]:data())
-       s = path
-       for j=1,4 do
-            s = s..','..predictions[i][j]
-       end
-       file:write(s..'\n')
-    end
-
-    file.close()
+   local paths = {}
+   for i=1,(predictions:size(1)) do
+      paths[i] = ffi.string(dataloader.dataset.imageInfo.imagePath[indices[i]]:data())
+   end
+   return paths, predictions
 end
 
 return M.Tester

--- a/test.lua
+++ b/test.lua
@@ -1,0 +1,63 @@
+--
+--  Copyright (c) 2016, Facebook, Inc.
+--  All rights reserved.
+--
+--  This source code is licensed under the BSD-style license found in the
+--  LICENSE file in the root directory of this source tree. An additional grant
+--  of patent rights can be found in the PATENTS file in the same directory.
+--
+-- require 'torch'
+require 'nn'
+
+-- torch.setdefaulttensortype('torch.FloatTensor')
+-- torch.setnumthreads(1)
+
+local M = {}
+local Tester = torch.class('resnet.Tester', M)
+
+function Tester:__init(model, opt)
+   self.model = model
+   self.nCrops = opt.tenCrop and 10 or 1
+end
+
+function Trainer:test(dataloader)
+   self.model:evaluate()
+
+   local predictions = {}
+   local timer = torch.Timer()
+   local size = dataloader:size()
+
+   for n, sample in dataloader:run() do
+      local output = model:forward(sample.input:cuda():contiguous()):float()
+      if self.nCrops > 1 then
+        -- Sum over crops
+        output = output:view(output:size(1) / nCrops, nCrops, output:size(2))
+          --:exp()
+          :sum(2):squeeze(2)
+       output = output / nCrops
+    end
+
+    for i=1,(#output)[1] do
+       predictions[count] = {['name']=sample.path[i], ['output']=output[i]}
+    end
+    print((' | Test: [%d/%d]    Time %.3f '):format(
+       n, size, timer:time().real))
+    timer:reset()
+
+
+
+
+
+    file = io.open('output.csv', 'w')
+
+    for i=1,(len(predictions)-1) do
+       print(predictions[i])
+       s = predictions[i]['name']
+       for j=1,4 do
+            s = s..','..predictions[i]['output'][j]
+       end
+       file:write(s..'\n')
+    end
+
+    file.close()
+end

--- a/test.lua
+++ b/test.lua
@@ -7,7 +7,7 @@
 --  of patent rights can be found in the PATENTS file in the same directory.
 --
 -- require 'torch'
-
+--
 -- torch.setdefaulttensortype('torch.FloatTensor')
 -- torch.setnumthreads(1)
 
@@ -26,8 +26,8 @@ function Tester:test(dataloader)
    local size = dataloader:size()
    local numImages = dataloader.__size
    local indices = torch.Tensor(numImages):zero()
-  --  Num classes??????
-   local predictions = torch.Tensor(numImages, 4):zero()
+   local numClasses = #dataloader.dataset.classList
+   local predictions = torch.Tensor(numImages, numClasses):zero()
    local numProcessed = 0
 
    for n, sample in dataloader:run() do


### PR DESCRIPTION
Adds flag -predict that predicts output of the model on each image from `data/test` folder and writes down `output.t7`. For each image this file contains the path to the image and the output of the model (or average output of ten runs if `tenCrop`).

Example usage:
th main.lua -predict True -data data_dir/ -retrain model.t7 -tenCrop True