### PR TITLE
New dataset support

### DIFF
--- a/datasets/cifar100-gen.lua
+++ b/datasets/cifar100-gen.lua
@@ -1,0 +1,67 @@
+--
+--  Copyright (c) 2016, Facebook, Inc.
+--  All rights reserved.
+--
+--  This source code is licensed under the BSD-style license found in the
+--  LICENSE file in the root directory of this source tree. An additional grant
+--  of patent rights can be found in the PATENTS file in the same directory.
+--
+
+------------
+-- This file automatically downloads the CIFAR-100 dataset from
+--    http://www.cs.toronto.edu/~kriz/cifar-100-binary.tar.gz
+-- It is based on cifar10-gen.lua
+-- Ludovic Trottier
+------------
+
+local URL = 'http://www.cs.toronto.edu/~kriz/cifar-100-binary.tar.gz'
+
+local M = {}
+
+local function convertCifar100BinToTorchTensor(inputFname)
+   local m=torch.DiskFile(inputFname, 'r'):binary()
+   m:seekEnd()
+   local length = m:position() - 1
+   local nSamples = length / 3074 -- 1 coarse-label byte, 1 fine-label byte, 3072 pixel bytes
+
+   assert(nSamples == math.floor(nSamples), 'expecting numSamples to be an exact integer')
+   m:seek(1)
+
+   local coarse = torch.ByteTensor(nSamples)
+   local fine = torch.ByteTensor(nSamples)
+   local data = torch.ByteTensor(nSamples, 3, 32, 32)
+   for i=1,nSamples do
+      coarse[i] = m:readByte()
+      fine[i]   = m:readByte()
+      local store = m:readByte(3072)
+      data[i]:copy(torch.ByteTensor(store))
+   end
+
+   local out = {}
+   out.data = data
+   -- This is *very* important. The downloaded files have labels 0-9, which do
+   -- not work with CrossEntropyCriterion
+   out.labels = fine + 1
+
+   return out
+end
+
+function M.exec(opt, cacheFile)
+   print("=> Downloading CIFAR-100 dataset from " .. URL)
+   
+   local ok = os.execute('curl ' .. URL .. ' | tar xz -C  gen/')
+   assert(ok == true or ok == 0, 'error downloading CIFAR-100')
+
+   print(" | combining dataset into a single file")
+   
+   local trainData = convertCifar100BinToTorchTensor('gen/cifar-100-binary/train.bin')
+   local testData = convertCifar100BinToTorchTensor('gen/cifar-100-binary/test.bin')
+
+   print(" | saving CIFAR-100 dataset to " .. cacheFile)
+   torch.save(cacheFile, {
+      train = trainData,
+      val = testData,
+   })
+end
+
+return M

--- a/datasets/cifar100.lua
+++ b/datasets/cifar100.lua
@@ -1,0 +1,68 @@
+--
+--  Copyright (c) 2016, Facebook, Inc.
+--  All rights reserved.
+--
+--  This source code is licensed under the BSD-style license found in the
+--  LICENSE file in the root directory of this source tree. An additional grant
+--  of patent rights can be found in the PATENTS file in the same directory.
+--
+
+------------
+-- This file is downloading and transforming CIFAR-100.
+-- It is based on cifar10.lua
+-- Ludovic Trottier
+------------
+
+local t = require 'datasets/transforms'
+
+local M = {}
+local CifarDataset = torch.class('resnet.CifarDataset', M)
+
+function CifarDataset:__init(imageInfo, opt, split)
+   assert(imageInfo[split], split)
+   self.imageInfo = imageInfo[split]
+   self.split = split
+end
+
+function CifarDataset:get(i)
+   local image = self.imageInfo.data[i]:float()
+   local label = self.imageInfo.labels[i]
+
+   return {
+      input = image,
+      target = label,
+   }
+end
+
+function CifarDataset:size()
+   return self.imageInfo.data:size(1)
+end
+
+
+-- Computed from entire CIFAR-100 training set with this code:
+--      dataset = torch.load('cifar100.t7')
+--      tt = dataset.train.data:double();
+--      tt = tt:transpose(2,4);
+--      tt = tt:reshape(50000*32*32, 3);
+--      tt:mean(1)
+--      tt:std(1)
+local meanstd = {
+   mean = {129.3, 124.1, 112.4},
+   std  = {68.2,  65.4,  70.4},
+}
+
+function CifarDataset:preprocess()
+   if self.split == 'train' then
+      return t.Compose{
+         t.ColorNormalize(meanstd),
+         t.HorizontalFlip(0.5),
+         t.RandomCrop(32, 4),
+      }
+   elseif self.split == 'val' then
+      return t.ColorNormalize(meanstd)
+   else
+      error('invalid split: ' .. self.split)
+   end
+end
+
+return M.CifarDataset

--- a/models/resnet.lua
+++ b/models/resnet.lua
@@ -143,6 +143,23 @@ local function createModel(opt)
       model:add(Avg(8, 8, 1, 1))
       model:add(nn.View(64):setNumInputDims(3))
       model:add(nn.Linear(64, 10))
+   elseif opt.dataset == 'cifar100' then
+      -- Model type specifies number of layers for CIFAR-100 model
+      assert((depth - 2) % 6 == 0, 'depth should be one of 20, 32, 44, 56, 110, 1202')
+      local n = (depth - 2) / 6
+      iChannels = 16
+      print(' | ResNet-' .. depth .. ' CIFAR-100')
+
+      -- The ResNet CIFAR-100 model
+      model:add(Convolution(3,16,3,3,1,1,1,1))
+      model:add(SBatchNorm(16))
+      model:add(ReLU(true))
+      model:add(layer(basicblock, 16, n))
+      model:add(layer(basicblock, 32, n, 2))
+      model:add(layer(basicblock, 64, n, 2))
+      model:add(Avg(8, 8, 1, 1))
+      model:add(nn.View(64):setNumInputDims(3))
+      model:add(nn.Linear(64, 100))
    else
       error('invalid dataset: ' .. opt.dataset)
    end

--- a/opts.lua
+++ b/opts.lua
@@ -17,7 +17,7 @@ function M.parse(arg)
    cmd:text('Options:')
     ------------ General options --------------------
    cmd:option('-data',       '',         'Path to dataset')
-   cmd:option('-dataset',    'imagenet', 'Options: imagenet | cifar10')
+   cmd:option('-dataset',    'imagenet', 'Options: imagenet | cifar10 | cifar100')
    cmd:option('-manualSeed', 0,          'Manually set RNG seed')
    cmd:option('-nGPU',       1,          'Number of GPUs to use by default')
    cmd:option('-backend',    'cudnn',    'Options: cudnn | cunn')
@@ -78,6 +78,10 @@ function M.parse(arg)
       -- Default shortcutType=A and nEpochs=164
       opt.shortcutType = opt.shortcutType == '' and 'A' or opt.shortcutType
       opt.nEpochs = opt.nEpochs == 0 and 164 or opt.nEpochs
+   elseif opt.dataset == 'cifar100' then
+       -- Default shortcutType=A and nEpochs=164
+       opt.shortcutType = opt.shortcutType == '' and 'A' or opt.shortcutType
+       opt.nEpochs = opt.nEpochs == 0 and 164 or opt.nEpochs
    else
       cmd:error('unknown dataset: ' .. opt.dataset)
    end

--- a/train.lua
+++ b/train.lua
@@ -169,6 +169,8 @@ function Trainer:learningRate(epoch)
       decay = math.floor((epoch - 1) / 30)
    elseif self.opt.dataset == 'cifar10' then
       decay = epoch >= 122 and 2 or epoch >= 81 and 1 or 0
+   elseif self.opt.dataset == 'cifar100' then
+      decay = epoch >= 122 and 2 or epoch >= 81 and 1 or 0
    end
    return self.opt.LR * math.pow(0.1, decay)
 end


### PR DESCRIPTION
These changes add support for CIFAR-100 dataset. It follows the same architecture as CIFAR-10.

1. The files "datasets/cifar100-gen.lua" and "datasets/cifar100.lua" automatically download and pre-process the dataset.
2. Added option "cifar100" in "opts.lua".
3. Added learning rate schedule in "train.lua".
4. Added a CIFAR-100 resnet model in "models/resnet.lua", which is the same as CIFAR-10 model, appart from the last layer with has 100 output neurons instead of 10.