### PR TITLE
Use FloatTensor(3, 256, 256):fix(.5) as image in case of reading error

### DIFF
--- a/datasets/imagenet.lua
+++ b/datasets/imagenet.lua
@@ -49,7 +49,11 @@ function ImagenetDataset:_loadImage(path)
       assert(f, 'Error reading: ' .. tostring(path))
       local data = f:read('*a')
       f:close()
-
+      if data == nil then
+         print('unable to read file: ' .. tostring(path))
+         -- In this bad case, just fill a mean image.
+         return torch.FloatTensor(3, 256, 256):fill(.5)
+      end
       local b = torch.ByteTensor(string.len(data))
       ffi.copy(b:data(), data, b:size(1))
 


### PR DESCRIPTION
I find in very rare case, I still get nil from f:read('a'), it could be a corruption of the disk file or a corruption of RAM. In this case, instead of throwing error, I may want to continue my training process by using a mean image.