### PR TITLE
Fixed model-not-found print statement.

### DIFF
--- a/pretrained/extract-features.lua
+++ b/pretrained/extract-features.lua
@@ -38,7 +38,7 @@ local list_of_filenames = {}
 local batch_size = 1
 
 if not paths.filep(arg[1]) then
-    io.stderr:write('Model file not found at ' .. f .. '\n')
+    io.stderr:write('Model file not found at ' .. arg[1] .. '\n')
     os.exit(1)
 end
     


### PR DESCRIPTION
This fixes the print statement when the model file is not found. `f` in the previous code was not defined at this point.