### PR TITLE
Added :cuda() calls to load_model in classify.lua and extract-features.lua

### DIFF
--- a/pretrained/classify.lua
+++ b/pretrained/classify.lua
@@ -32,7 +32,7 @@ end
 
 
 -- Load the model
-local model = torch.load(arg[1])
+local model = torch.load(arg[1]):cuda()
 local softMaxLayer = cudnn.SoftMax():cuda()
 
 -- add Softmax layer

--- a/pretrained/extract-features.lua
+++ b/pretrained/extract-features.lua
@@ -72,7 +72,7 @@ local number_of_files = #list_of_filenames
 if batch_size > number_of_files then batch_size = number_of_files end
 
 -- Load the model
-local model = torch.load(arg[1])
+local model = torch.load(arg[1]):cuda()
 
 -- Remove the fully connected layer
 assert(torch.type(model:get(#model.modules)) == 'nn.Linear')


### PR DESCRIPTION
I've added :cuda() calls to load_model in classify.lua and extract-features.lua to fix 'Only Cuda supported duh!' error when using finetuned models