### PR TITLE
Make target CudaLong

### DIFF
--- a/train.lua
+++ b/train.lua
@@ -156,8 +156,7 @@ function Trainer:copyInputs(sample)
    self.input = self.input or (self.opt.nGPU == 1
       and torch.CudaTensor()
       or cutorch.createCudaHostTensor())
-   self.target = self.target or torch.CudaTensor()
-
+   self.target = self.target or (torch.CudaLongTensor and torch.CudaLongTensor()or torch.CudaTensor())
    self.input:resize(sample.input:size()):copy(sample.input)
    self.target:resize(sample.target:size()):copy(sample.target)
 end


### PR DESCRIPTION
Make target CudaLong if available to avoid unnecessary casts