### PR TITLE
Fix OOM errors when reloading certain large checkpointed models

### DIFF
--- a/models/init.lua
+++ b/models/init.lua
@@ -27,6 +27,7 @@ function M.setup(opt, checkpoint)
       assert(paths.filep(opt.retrain), 'File not found: ' .. opt.retrain)
       print('Loading model from file: ' .. opt.retrain)
       model = torch.load(opt.retrain):cuda()
+      model.__memoryOptimized = nil
    else
       print('=> Creating model from file: models/' .. opt.netType .. '.lua')
       model = require('models/' .. opt.netType)(opt)


### PR DESCRIPTION
I regularly have OOM problems reloading checkpoints of large models for further training (models that trained fine on the same machine before). This appears to resolves those issues for me.