### PR TITLE
make default shortcutType to B

### DIFF
--- a/opts.lua
+++ b/opts.lua
@@ -41,7 +41,7 @@ function M.parse(arg)
    ---------- Model options ----------------------------------
    cmd:option('-netType',      'resnet', 'Options: resnet | preresnet')
    cmd:option('-depth',        34,       'ResNet depth: 18 | 34 | 50 | 101 | ...', 'number')
-   cmd:option('-shortcutType', '',       'Options: A | B | C')
+   cmd:option('-shortcutType', 'B',      'Options: A | B | C')
    cmd:option('-retrain',      'none',   'Path to model to retrain with')
    cmd:option('-optimState',   'none',   'Path to an optimState to reload from')
    ---------- Model options ----------------------------------


### PR DESCRIPTION
Current default `shortcutType=''`. Because empty string is evaluated to a `true` value,  `shortcutType = opt.shortcutType or 'B'` still give `shortcutType=''`. This might cause unexpected behavior in default settings. 