### PR TITLE
exclude the .DS_Store file for Mac OSX users

### DIFF
--- a/datasets/imagenet-gen.lua
+++ b/datasets/imagenet-gen.lua
@@ -25,7 +25,7 @@ local function findClasses(dir)
    local classList = {}
    local classToIdx = {}
    for _ ,class in ipairs(dirs) do
-      if not classToIdx[class] and class ~= '.' and class ~= '..' then
+      if not classToIdx[class] and class ~= '.' and class ~= '..' and class ~= '.DS_Store' then
          table.insert(classList, class)
          classToIdx[class] = #classList
       end


### PR DESCRIPTION
for Mac users this file may be added to the list of targets, thus, should be removed to fulfil the loss function assertion: cur_target >= 0 && cur_target < n_classes