### PR TITLE
Replace sort with topk when compute scores

### DIFF
--- a/train.lua
+++ b/train.lua
@@ -134,11 +134,11 @@ function Trainer:computeScore(output, target, nCrops)
    -- Coputes the top1 and top5 error rate
    local batchSize = output:size(1)
 
-   local _ , predictions = output:float():sort(2, true) -- descending
+   local _ , predictions = output:float():topk(5, 2, true, true) -- descending
 
    -- Find which predictions match the target
    local correct = predictions:eq(
-      target:long():view(batchSize, 1):expandAs(output))
+      target:long():view(batchSize, 1):expandAs(predictions))
 
    -- Top-1 score
    local top1 = 1.0 - (correct:narrow(2, 1, 1):sum() / batchSize)


### PR DESCRIPTION
Currently, the predicted scores are fully sorted for each sample when compute top-k accuracy. It could be time consuming when the number of classes is much larger.

We fix this by replacing the `sort` function with `topk` that only does the partial sort. When predicting 100,000 classes with options `-nGPU 8 -nThreads 16 -batchSize 256 -netType resnet -depth 101`, the training time of each iteration reduces from about **2.7s** to **0.9s**.