### PR TITLE
Add support for CudaHalfTensor, CudaDoubleTensor training

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -16,6 +16,9 @@ local Trainer = require 'train'
 local opts = require 'opts'
 local checkpoints = require 'checkpoints'
 
+-- we don't  change this to the 'correct' type (e.g. HalfTensor), because math
+-- isn't supported on that type.  Type conversion later will handle having
+-- the correct type.
 torch.setdefaulttensortype('torch.FloatTensor')
 torch.setnumthreads(1)
 

--- a/models/preresnet.lua
+++ b/models/preresnet.lua
@@ -221,7 +221,7 @@ local function createModel(opt)
    for k,v in pairs(model:findModules('nn.Linear')) do
       v.bias:zero()
    end
-   model:cuda()
+   model:type(opt.tensorType)
 
    if opt.cudnn == 'deterministic' then
       model:apply(function(m)

--- a/models/resnet.lua
+++ b/models/resnet.lua
@@ -191,7 +191,7 @@ local function createModel(opt)
    for k,v in pairs(model:findModules('nn.Linear')) do
       v.bias:zero()
    end
-   model:cuda()
+   model:type(opt.tensorType)
 
    if opt.cudnn == 'deterministic' then
       model:apply(function(m)

--- a/opts.lua
+++ b/opts.lua
@@ -23,6 +23,7 @@ function M.parse(arg)
    cmd:option('-backend',    'cudnn',    'Options: cudnn | cunn')
    cmd:option('-cudnn',      'fastest',  'Options: fastest | default | deterministic')
    cmd:option('-gen',        'gen',      'Path to save generated files')
+   cmd:option('-precision', 'single',    'Options: single | double | half')
    ------------- Data options ------------------------
    cmd:option('-nThreads',        2, 'number of data loading threads')
    ------------- Training options --------------------
@@ -86,12 +87,21 @@ function M.parse(arg)
       cmd:error('unknown dataset: ' .. opt.dataset)
    end
 
+   if opt.precision == nil or opt.precision == 'single' then
+      opt.tensorType = 'torch.CudaTensor'
+   elseif opt.precision == 'double' then
+      opt.tensorType = 'torch.CudaDoubleTensor'
+   elseif opt.precision == 'half' then
+      opt.tensorType = 'torch.CudaHalfTensor'
+   else
+      cmd:error('unknown precision: ' .. opt.precision)
+   end
+
    if opt.resetClassifier then
       if opt.nClasses == 0 then
          cmd:error('-nClasses required when resetClassifier is set')
       end
    end
-
    if opt.shareGradInput and opt.optnet then
       cmd:error('error: cannot use both -shareGradInput and -optnet')
    end

--- a/train.lua
+++ b/train.lua
@@ -150,13 +150,23 @@ function Trainer:computeScore(output, target, nCrops)
    return top1 * 100, top5 * 100
 end
 
+local function getCudaTensorType(tensorType)
+  if tensorType == 'torch.CudaHalfTensor' then
+     return cutorch.createCudaHostHalfTensor()
+  elseif tensorType == 'torch.CudaDoubleTensor' then
+    return cutorch.createCudaHostDoubleTensor()
+  else
+     return cutorch.createCudaHostTensor()
+  end
+end
+
 function Trainer:copyInputs(sample)
    -- Copies the input to a CUDA tensor, if using 1 GPU, or to pinned memory,
    -- if using DataParallelTable. The target is always copied to a CUDA tensor
    self.input = self.input or (self.opt.nGPU == 1
-      and torch.CudaTensor()
-      or cutorch.createCudaHostTensor())
-   self.target = self.target or (torch.CudaLongTensor and torch.CudaLongTensor()or torch.CudaTensor())
+      and torch[self.opt.tensorType:match('torch.(%a+)')]()
+      or getCudaTensorType(self.opt.tensorType))
+   self.target = self.target or (torch.CudaLongTensor and torch.CudaLongTensor())
    self.input:resize(sample.input:size()):copy(sample.input)
    self.target:resize(sample.target:size()):copy(sample.target)
 end


### PR DESCRIPTION
The -precision flag now supports single/double/half for specifying tensor precision with either single or multi gpu (DataParallel) mode.

Note that this does not add support for the pre-trained models
in classify, extract-features.