### PR TITLE
Fix OOM errors when reloading certain large checkpointed models

### DIFF
--- a/models/init.lua
+++ b/models/init.lua
@@ -23,6 +23,7 @@ function M.setup(opt, checkpoint)
       assert(paths.filep(modelPath), 'Saved model not found: ' .. modelPath)
       print('=> Resuming model from ' .. modelPath)
       model = torch.load(modelPath):type(opt.tensorType)
+      model.__memoryOptimized = nil
    elseif opt.retrain ~= 'none' then
       assert(paths.filep(opt.retrain), 'File not found: ' .. opt.retrain)
       print('Loading model from file: ' .. opt.retrain)


### PR DESCRIPTION
PR https://github.com/facebook/fb.resnet.torch/pull/129 fixed an OOM issue when reloading large models via `retrain`, but forgot to do it when reloading checkpoints. This PR corrects that.