### PR TITLE
Fix memory leak when saving models 

### DIFF
--- a/checkpoints.lua
+++ b/checkpoints.lua
@@ -8,6 +8,16 @@
 --
 local checkpoint = {}
 
+local function deepDelete(tbl)
+   for k, v in pairs(tbl) do
+      if type(v) == 'table' then
+         deepDelete(v)
+      else
+         v = nil
+      end
+   end
+end
+
 local function deepCopy(tbl)
    -- creates a copy of a network with new modules and the same tensors
    local copy = {}
@@ -66,6 +76,9 @@ function checkpoint.save(epoch, model, optimState, isBestModel, opt)
    if isBestModel then
       torch.save(paths.concat(opt.save, 'model_best.t7'), model)
    end
+   deepDelete(model)
+   model = nil
+   collectgarbage()
 end
 
 return checkpoint

--- a/checkpoints.lua
+++ b/checkpoints.lua
@@ -14,6 +14,8 @@ local function deepCopy(tbl)
    for k, v in pairs(tbl) do
       if type(v) == 'table' then
          copy[k] = deepCopy(v)
+      elseif torch.type(v):find('Tensor') then
+        copy[k] = v:float()
       else
          copy[k] = v
       end


### PR DESCRIPTION
When saving checkpoints the amount of (CPU) RAM memory used increases every time. It seems that the garbage collector doesn't free the unreferenced memory. Copying each Tensor directly to the (CPU) RAM fixed the problem for me. I think issue #109 could be due to this. When the occupied memory grows, the process freezes and the OS kills the process, just like @DmitryUlyanov said.
Commit d4f53da saves some more memory. Useful if you have big models and not so much RAM available.