### PR TITLE
Remove a bug during 10-crop testing

### DIFF
--- a/train.lua
+++ b/train.lua
@@ -102,7 +102,6 @@ function Trainer:test(epoch, dataloader)
 
       local output = self.model:forward(self.input):float()
       local batchSize = output:size(1) / nCrops
-      local loss = self.criterion:forward(self.model.output, self.target)
 
       local top1, top5 = self:computeScore(output, sample.target, nCrops)
       top1Sum = top1Sum + top1*batchSize


### PR DESCRIPTION
If including the computation of loss during test, 10-crop testing will report an error like this (with batch size 128). 

/sde/jli59/torch/install/bin/luajit: /sde/jli59/torch/install/share/lua/5.1/nn/THNN.lua:110: bad argument #2 to 'v' (mismatch between the batch size of input (120) and that of target (12) at /sde/jli59/torch/extra/cunn/lib/THCUNN/generic/ClassNLLCriterion.cu:39)
stack traceback:
        [C]: in function 'v'
        /sde/jli59/torch/install/share/lua/5.1/nn/THNN.lua:110: in function 'ClassNLLCriterion_updateOutput'
        ...i59/torch/install/share/lua/5.1/nn/ClassNLLCriterion.lua:44: in function 'updateOutput'
        ...torch/install/share/lua/5.1/nn/CrossEntropyCriterion.lua:20: in function 'forward'
        ./train.lua:105: in function 'test'
        main.lua:42: in main chunk
        [C]: in function 'dofile'
        ...li59/torch/install/lib/luarocks/rocks/trepl/scm-1/bin/th:150: in main chunk
        [C]: at 0x00405d50

The reason is that the output dimension of the model is not the same as the target label's dimension. They differ by 10 times. Just avoiding the loss computation can solve this issue.

Also, computing the loss is not necessary for testing.

Thanks