### PR TITLE
Bug fix: get 'gen' directory's path from command line options

### DIFF
--- a/datasets/init.lua
+++ b/datasets/init.lua
@@ -22,7 +22,7 @@ end
 function M.create(opt, split)
    local cachePath = paths.concat(opt.gen, opt.dataset .. '.t7')
    if not paths.filep(cachePath) or not isvalid(opt, cachePath) then
-      paths.mkdir('gen')
+      paths.mkdir(opt.gen)
 
       local script = paths.dofile(opt.dataset .. '-gen.lua')
       script.exec(opt, cachePath)


### PR DESCRIPTION
Good morning!

The current version creates the directory for saving generated files at `./gen`, no matter what value is given to the option `opt.gen`. So I made a simple patch.

Thanks for reading!
